### PR TITLE
fix scan function

### DIFF
--- a/HashDB.java
+++ b/HashDB.java
@@ -77,6 +77,7 @@ import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.RefType;
 import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
 
 import java.net.URL;
 import java.security.SecureRandom;
@@ -806,6 +807,7 @@ public class HashDB extends GhidraScript {
 						showProgressBar("Scanning functions", true, true, 0);
 						List<Address> calls = getCallAddresses(functions.get(0));
 						taskMonitor.initialize(calls.size());
+						
 						final class Resolver extends SwingWorker<Void, Object> {
 							@Override
 							protected Void doInBackground() throws Exception {
@@ -1693,7 +1695,7 @@ public class HashDB extends GhidraScript {
 			throw new IllegalStateException();
 		DecompInterface decompInterface = new DecompInterface();
 		decompInterface.openProgram(currentProgram);
-		DecompileResults decompileResults = decompInterface.decompileFunction(caller, 120, monitor);
+		DecompileResults decompileResults = decompInterface.decompileFunction(caller, 120, null);
 		if (!decompileResults.decompileCompleted())
 			throw new IllegalStateException();
 		HighFunction highFunction = decompileResults.getHighFunction();
@@ -1735,12 +1737,13 @@ public class HashDB extends GhidraScript {
 
 	private List<Address> getCallAddresses(Function deobfuscator) {
 		List<Address> addresses = new ArrayList<Address>();
-		for (Reference ref : getReferencesTo(deobfuscator.getEntryPoint())) {
+		ReferenceIterator refIter = currentProgram.getReferenceManager().getReferencesTo(deobfuscator.getEntryPoint());
+		while (refIter.hasNext()) {
+			Reference ref =refIter.next();
 			if (ref.getReferenceType() != RefType.UNCONDITIONAL_CALL)
 				continue;
 			addresses.add(ref.getFromAddress());
 		}
-
 		return addresses;
 	}
 }


### PR DESCRIPTION
### Issue
The Scan function is currently broken as the method `getCallAddresses` throws a `NullPointerException` because `getReferencesTo` returns an array of null references. 
The cause is that the [monitor check](https://github.com/NationalSecurityAgency/ghidra/blame/22f733c19ed6934ddaefa9c06fd1a047c811de66/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java#L2146) fails thus the array isn't populated.
The monitor seems to be cancelled and `getConstantCallArgument` fails as well while trying to decompile the function.

### Fix
As written in the [Ghidra documentation](https://github.com/NationalSecurityAgency/ghidra/blame/22f733c19ed6934ddaefa9c06fd1a047c811de66/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java#L2132) use `ReferenceManager::getReferencesTo` instead, since we will be accessing all the references.